### PR TITLE
Update used JDKs to Java 8.

### DIFF
--- a/src/main/resources/archetype-resources/.travis.yml
+++ b/src/main/resources/archetype-resources/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
 addons:
   apt:
@@ -24,4 +23,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    jdk: oraclejdk7
+    jdk: oraclejdk8

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -29,9 +29,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <graylog2.version>1.2.0</graylog2.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <graylog2.version>2.0.0-SNAPSHOT</graylog2.version>
         <graylog2.plugin-dir>/usr/share/graylog-server/plugin</graylog2.plugin-dir>
     </properties>
 


### PR DESCRIPTION
As Graylog 2.0 will require a Java 8 runtime, plugins should (although
this is not required) be written and built on Java 8. Therefore this
commit changes the compiler's target and language level, as well als
travis' build config to Java 8.

This should be merged either to a branch in preparation of 2.0 or when
Graylog2/graylog2-server#1479 is merged.
