### PR TITLE
Add and use graylog-plugin.properties

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -52,9 +52,17 @@
             <resource><directory>build</directory></resource>
             <resource>
               <directory>src/main/resources</directory>
+              <filtering>true</filtering>
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <skipAssembly>true</skipAssembly>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -52,12 +52,22 @@
             <resource><directory>build</directory></resource>
             <resource>
               <directory>src/main/resources</directory>
-              <excludes>
-                <exclude>**/*.properties</exclude>
-              </excludes>
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Graylog-Plugin-Properties-Path>${project.groupId}.${project.artifactId}</Graylog-Plugin-Properties-Path>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/resources/archetype-resources/src/main/java/__pluginClassName__MetaData.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginClassName__MetaData.java
@@ -12,6 +12,8 @@ import java.util.Set;
  * Implement the PluginMetaData interface here.
  */
 public class ${pluginClassName}MetaData implements PluginMetaData {
+    private static final String PLUGIN_PROPERTIES = "${groupId}.${artifactId}/graylog-plugin.properties";
+
     @Override
     public String getUniqueId() {
         return "${package}.${pluginClassName}Plugin";
@@ -24,19 +26,17 @@ public class ${pluginClassName}MetaData implements PluginMetaData {
 
     @Override
     public String getAuthor() {
-        // TODO Insert author name
-        return "${pluginClassName} author";
+        return "${ownerName} <${ownerEmail}>";
     }
 
     @Override
     public URI getURL() {
-        // TODO Insert correct plugin website
-        return URI.create("https://www.graylog.org/");
+        return URI.create("https://github.com/${githubRepo}");
     }
 
     @Override
     public Version getVersion() {
-        return new Version(1, 0, 0);
+        return Version.fromPluginProperties(getClass(), PLUGIN_PROPERTIES, "version", Version.from(0, 0, 0, "unknown"));
     }
 
     @Override
@@ -47,7 +47,7 @@ public class ${pluginClassName}MetaData implements PluginMetaData {
 
     @Override
     public Version getRequiredVersion() {
-        return new Version(2, 0, 0);
+        return Version.fromPluginProperties(getClass(), PLUGIN_PROPERTIES, "graylog.version", Version.from(0, 0, 0, "unknown"));
     }
 
     @Override

--- a/src/main/resources/archetype-resources/src/main/resources/__groupId__.__artifactId__/graylog-plugin.properties
+++ b/src/main/resources/archetype-resources/src/main/resources/__groupId__.__artifactId__/graylog-plugin.properties
@@ -1,0 +1,12 @@
+# The plugin version
+version=${project.version}
+
+# The required Graylog server version
+graylog.version=${graylog.version}
+
+# When set to true (the default) the plugin gets a separate class loader
+# when loading the plugin. When set to false, the plugin shares a class loader
+# with other plugins that have isolated=false.
+#
+# Do not disable this unless this plugin depends on another plugin!
+isolated=true


### PR DESCRIPTION
Creates a `graylog-plugin.properties` file for the version and required version settings and the `isolated` flag.

Requires https://github.com/Graylog2/graylog2-server/pull/2535
