### PR TITLE
Adding property which points to server checkout.

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                       xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
-                      name="vertx" partial="false">
+                      name="graylog-plugin" partial="false">
     <requiredProperties>
         <requiredProperty key="pluginClassName">
             <defaultValue/>
@@ -21,6 +21,10 @@
 
         <requiredProperty key="ownerEmail">
             <defaultValue/>
+        </requiredProperty>
+
+        <requiredProperty key="serverCheckoutPath">
+            <defaultValue>../graylog2-server</defaultValue>
         </requiredProperty>
     </requiredProperties>
 
@@ -69,7 +73,7 @@
                 <include>GETTING-STARTED.md</include>
                 <include>package.json</include>
                 <include>webpack.config.js</include>
-                <include>build.config.js.sample</include>
+                <include>build.config.js</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/src/main/resources/archetype-resources/build.config.js
+++ b/src/main/resources/archetype-resources/build.config.js
@@ -2,5 +2,5 @@ const path = require('path');
 
 module.exports = {
   // Make sure that this is the correct path to the web interface part of the Graylog server repository.
-  web_src_path: path.resolve(__dirname, '../graylog2-server/graylog2-web-interface'),
+  web_src_path: path.resolve(__dirname, '${serverCheckoutPath}', 'graylog2-web-interface'),
 };

--- a/src/main/resources/archetype-resources/package.json
+++ b/src/main/resources/archetype-resources/package.json
@@ -17,29 +17,9 @@
   "author": "${ownerName} <${ownerEmail}>",
   "license": "MIT",
   "dependencies": {
-    "history": "^1.17.0",
-    "react": "0.14.x",
-    "react-bootstrap": "^0.28.1",
-    "react-dom": "^0.14.5",
-    "react-router": "~1.0.0",
-    "react-router-bootstrap": "^0.19.0",
-    "reflux": "^0.2.12"
   },
   "devDependencies": {
-    "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
-    "css-loader": "^0.23.1",
-    "eslint-config-graylog": "^1.0.0",
-    "file-loader": "^0.9.0",
-    "graylog-web-plugin": "latest",
-    "graylog-web-manifests": "*",
-    "json-loader": "^0.5.4",
-    "less": "^2.5.3",
-    "less-loader": "^2.2.1",
-    "react-hot-loader": "^1.3.0",
-    "react-proxy-loader": "^0.3.4",
-    "style-loader": "^0.13.0",
-    "url-loader": "^0.5.6",
-    "webpack": "^1.12.2"
+    "webpack": "^1.12.2",
+    "graylog-web-plugin": "file:${serverCheckoutPath}/graylog2-web-interface/packages/graylog-web-plugin"
   }
 }


### PR DESCRIPTION
Dependencies are being moved into the `graylog-web-plugin` module, which is now located inside the server repo to ease building against a specific server version. Therefore we also require a server checkout for the build, for whose location we ask during the archetype now.
